### PR TITLE
Better fix for Autoload when running from get.php

### DIFF
--- a/app/code/local/Varien/Autoload.php
+++ b/app/code/local/Varien/Autoload.php
@@ -27,7 +27,7 @@ class Varien_Autoload
      */
     public function __construct()
     {
-        if (defined(BP)) {
+        if (defined('BP')) {
             self::$_BP = BP;
         }
         elseif (strpos($_SERVER["SCRIPT_FILENAME"], 'get.php') !== false) {
@@ -40,7 +40,7 @@ class Varien_Autoload
         if (extension_loaded('apc')) {
             self::$useAPC = TRUE;
         }
-        self::$cacheKey = self::CACHE_KEY_PREFIX . "_" . md5(self:$_BP);
+        self::$cacheKey = self::CACHE_KEY_PREFIX . "_" . md5(self::$_BP);
         self::registerScope(self::$_scope);
         self::loadCacheContent();
     }


### PR DESCRIPTION
I believe this bit:
define('BP', dirname(dirname(dirname(dirname(dirname(**FILE**))))));
does not work if the Autoload.php file is placed using modman. If you manually copy the file to docroot/app/code/local/Varien/Autoload.php I believe it works. 

The dirname bit will traverse up the real path as opposed to the symlinked path. I also used an internal variable instead of BP because later on BP may be redfined which throws a notice. 
