### PR TITLE
Fix package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name":"fbrnc/aoe_classpathcache",
+    "name":"AOEMedia/aoe_classpathcache",
     "type":"magento-module",
     "license":"OSL-3.0",
-    "homepage":"https://github.com/fbrnc/Aoe_ClassPathCache",
+    "homepage":"https://github.com/AOEMedia/Aoe_ClassPathCache",
     "description":"Class path cache for Magento autoloader.",
     "authors":[
         {


### PR DESCRIPTION
The package name was using the fbrnc namespace, which seems incorrect
since the fbrnc namespace'd version of the repository is out of date:
https://github.com/fbrnc/Aoe_ClassPathCache

Also the homepage was pointing there - I changed the name to use the
AOEMedia namespace and the homepage to point to the current repository:
https://github.com/AOEMedia/Aoe_ClassPathCache
