### PR TITLE
Avoid warnings from file_exists with non-existant classes. Do not cache ...

### DIFF
--- a/app/code/local/Varien/Autoload.php
+++ b/app/code/local/Varien/Autoload.php
@@ -178,14 +178,15 @@ class Varien_Autoload
      * Get full path
      *
      * @param $className
-     * @return mixed
+     * @return string|bool
      */
     static public function getFullPath($className) {
         if (!isset(self::$_cache[$className])) {
             $fullPath = self::searchFullPath(self::getFileFromClassName($className));
             if ($fullPath) {
-                self::$_cache[$className] = str_replace(self::$_BP . DIRECTORY_SEPARATOR, '', $fullPath);
+                $fullPath = str_replace(self::$_BP . DIRECTORY_SEPARATOR, '', $fullPath);
             }
+            self::$_cache[$className] = $fullPath;
             self::$_numberOfFilesAddedToCache++;
         }
         return self::$_cache[$className];


### PR DESCRIPTION
...not-found class names.

I had a case pop up in production where somehow (probably a CMS block) a class that doesn't exist was attempted to get loaded at one point. This generates warning whenever the cache is revalidated so this patch resolves it by suppressing file_exists warnings and also not caching entries that are not found (so they don't keep getting revalidated indefinitely).
