### PR TITLE
Fix Fatal Error 'Argument 1 passed to Varien_Autoload::setCache() ...'

### DIFF
--- a/app/code/local/Varien/Autoload.php
+++ b/app/code/local/Varien/Autoload.php
@@ -172,7 +172,12 @@ class Varien_Autoload
                 self::setCache($value);
             }
         } elseif (file_exists(self::getCacheFilePath())) {
-            self::setCache(unserialize(file_get_contents(self::getCacheFilePath())));
+            $cacheFilePath = unserialize(file_get_contents(self::getCacheFilePath()));
+			// If the file is corrupted, it resets cache
+		    if($cacheFilePath === false) {
+		        $cacheFilePath = array();
+		    }
+		    self::setCache($cacheFilePath);
         }
 
         if (file_exists(self::getRevalidateFlagPath()) && unlink(self::getRevalidateFlagPath())) {


### PR DESCRIPTION
I had this issue in Production "Argument 1 passed to Varien_Autoload::setCache() must be of the type array, boolean given, called in app/code/local/Varien/Autoload.php on line 175 and defined"

It's when the file classPathCache.php is corrupted. (Unknow reason)
But the way to resolve the issue is to test the result of the unserialize function.
If it's false we pass array() to setCache() 